### PR TITLE
Pipeline4build

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adding github action for building the extension and create a release. The action is triggered by tag on push (`[0-9]+.[0-9]+.[0-9]+`)